### PR TITLE
Skeleton video processing with tracking.js setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "react": "^15.6.1",
+    "tracking": "^1.1.3",
     "yarn": "^1.0.0"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,6 @@
     <title>Selfie Rater</title>
   </head>
   <body>
-    <span>Hello world</span>
+      <video id="myVideo" width="400" height="300" preload autoplay loop muted></video>
   </body>
 </html>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,26 @@
+/* global tracking */
+
+const SelfieTracker = () => {
+  SelfieTracker.base(this, 'constructor');
+};
+
+tracking.inherits(SelfieTracker, tracking.Tracker);
+
+// Per frame processing
+SelfieTracker.prototype.track = function(pixel, width, height) {
+  // ML scoring here
+
+  this.emit('track', {
+    // stuff to be passed as 'event'
+    data: [1, 2, 3], // Arbitrary for now
+  });
+};
+
+const selfieTracker = new SelfieTracker();
+
+selfieTracker.on('track', function(event) {
+  // Update scores in UI
+  console.log(event);
+});
+
+tracking.track('#myVideo', selfieTracker, {camera: true});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,9 @@ const commonConfig = merge([
       new webpack.ProvidePlugin({
         $: 'jquery',
       }),
+      new webpack.ProvidePlugin({
+        tracking: 'tracking',
+      }),
     ],
   },
   parts.loadFonts({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,8 +23,6 @@ const commonConfig = merge([
     plugins: [
       new webpack.ProvidePlugin({
         $: 'jquery',
-      }),
-      new webpack.ProvidePlugin({
         tracking: 'tracking',
       }),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6058,6 +6058,10 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
+tracking@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/tracking/-/tracking-1.1.3.tgz#cefd39b7175f96de1723d288ff15f28887b9db82"
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"


### PR DESCRIPTION
Added tracking.js for video processing.
Created the skeleton of a custom tracker for usage with scoring later.